### PR TITLE
Update 2020-12-16

### DIFF
--- a/src/assets/sass/_variables.scss
+++ b/src/assets/sass/_variables.scss
@@ -1,3 +1,4 @@
 $keio-pink: #ab035c;
 $keio-blue: #00205b;
+$shinjuku-leaf: #9fc105;
 $primary: $keio-blue;

--- a/src/assets/sass/main.scss
+++ b/src/assets/sass/main.scss
@@ -6,7 +6,8 @@
 
 $theme-colors: ( // color for bootstrap
   "keio-pink": $keio-pink,
-  "keio-blue": $keio-blue
+  "keio-blue": $keio-blue,
+  "shinjuku-leaf": $shinjuku-leaf
 );
 
 @import "~bootstrap";
@@ -29,6 +30,13 @@ h3 {
   font-weight: 500;
   padding: 0;
   margin-bottom: .8rem;
+}
+
+h4 {
+  font-size: 1.25rem;
+  font-weight: 500;
+  padding: 0;
+  margin-bottom: .5rem;
 }
 
 p {

--- a/src/assets/sass/main.scss
+++ b/src/assets/sass/main.scss
@@ -2,7 +2,10 @@
 @import "./position";
 
 // Noto Sans JP [400, 500, 700, 900] from Google Fonts
-@import url('https://fonts.googleapis.com/css?family=Noto+Sans+JP:400,500,700,900&display=swap&subset=japanese');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap');
+
+// Inter [400, 500, 700, 900] from Google Fonts
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;900&display=swap');
 
 $theme-colors: ( // color for bootstrap
   "keio-pink": $keio-pink,
@@ -13,7 +16,7 @@ $theme-colors: ( // color for bootstrap
 @import "~bootstrap";
 
 * {
-  font-family: "Noto Sans JP", sans-serif;
+  font-family: "Inter", "Noto Sans JP", sans-serif;
 }
 
 

--- a/src/components/TrainBoxS.vue
+++ b/src/components/TrainBoxS.vue
@@ -12,7 +12,7 @@
       :style="{ background: style }"
     >
       <span>{{ ikList[train.ik] }}</span>
-      <span>{{ tr }}</span>
+      <span>{{ train.tr }}</span>
       <span>{{ unyo }}</span>
       <span>{{ vehicle }}</span>
     </div>
@@ -117,20 +117,11 @@ export default class TrainBoxS extends Vue {
     //   : this.odptListJson.weekday;
   }
 
-  get tr() {
-    if (this.train.tr in this.list) return this.list[this.train.tr].tr;
-    return "[" + this.train.tr + "]";
-  }
-
   get unyo() {
-    if (this.train.tr in this.list) {
-      let num: number = +this.list[this.train.tr].un.slice(0, 2);
-      ++num;
-      --num;
-      let type: string = this.list[this.train.tr].un.slice(-1);
-      return (num % 2 ? num : ++num) + type;
-    }
-    return "-";
+    if (["K", "T"].some(type => this.train.tr.slice(-1) === type))
+      return Number(this.train.tr.slice(-3, -1)) + this.train.tr.slice(-1);
+    else
+      return Number(this.train.tr.slice(-4, -2)) + this.train.tr.slice(-2, -1);
   }
 
   get style() {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -349,7 +349,7 @@ export default class Home extends Vue {
           // Push to Object
           if (!resS.has(pos)) resS.set(pos, []);
           resS.get(pos)!.push({
-            tr: train["odpt:trainNumber"].slice(4),
+            tr: train["odpt:trainNumber"],
             sy: train["odpt:trainType"]!.split(".").pop()!,
             ki: train["odpt:railDirection"] === OdptDirection.W,
             dl: train["odpt:delay"]!,

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,25 +2,33 @@
   <div id="home">
     <b-alert variant="danger" class="error" :show="error">{{ error }}</b-alert>
     <b-alert :show="true" variant="info" class="m-0">
+      <h3>2020.10.30 ダイヤ修正 について</h3>
       <p>
-        2020.10.30 ダイヤ修正 はまだ対応していません。ごめんなさい。
+        種別変更（所謂「化け」）、および京王線内の運用番号を除いて対応しています。
       </p>
-      <h5>都営新宿線</h5>
-      <p>
-        種別・行き先は正確です。
-      </p>
-      <p>
-        列車番号が
-        <code>[0000]</code>
-        のように出ていますが、これは内部番号です。実際の列車番号とは異なりますので注意してください。
-      </p>
-      <h5>京王線</h5>
-      <p>
-        種別・行き先・列車番号ともに概ね正確です。一部の化けのみ間違っているかもしれません。
-      </p>
-      <p>
-        運用は参考として旧番号を表示しています。
-      </p>
+      <section>
+        <h4 class="d-inline-block mr-3">
+          <b-badge pill variant="shinjuku-leaf" class="text-white">S</b-badge>
+          都営新宿線
+        </h4>
+        <b-badge variant="secondary">2020.12.16 更新</b-badge>
+        <p>
+          種別・行き先・列車番号・運用番号ともにすべて正確です。ただし、京王線内の種別には追従できていません。<br />
+        </p>
+      </section>
+      <section>
+        <h4 class="d-inline-block mr-3">
+          <b-badge pill variant="keio-pink">KO</b-badge> 京王線
+        </h4>
+        <b-badge variant="secondary">2020.11.04 更新</b-badge>
+        <p>
+          種別・行き先・列車番号ともに概ね正確です。
+        </p>
+        <p>
+          化けについては旧データをそのまま表示しているため、間違いがあることも考えられます。<br />
+          運用は参考として旧番号を表示しています。
+        </p>
+      </section>
     </b-alert>
     <div class="zaisen">
       <div id="keio-section"></div>


### PR DESCRIPTION
ODPT が正規列車番号に対応したので対応アップデート

[東京都交通局の列車番号に関する変更\(2020\-12\-16\)](https://developer.odpt.org/news/%E6%9D%B1%E4%BA%AC%E9%83%BD%E4%BA%A4%E9%80%9A%E5%B1%80%E3%81%AE%E5%88%97%E8%BB%8A%E7%95%AA%E5%8F%B7%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E5%A4%89%E6%9B%B4(2020-12-16))

- feat: update S train number
- feat: update info
- feat: add Inter
